### PR TITLE
Bugfix for the popup h2 title

### DIFF
--- a/simpleshare.module
+++ b/simpleshare.module
@@ -220,7 +220,7 @@ function simpleshare_service_links() {
     }
     drupal_alter('simpleshare_service_links', $links);
     $links = theme('links', $links);
-    print theme('simpleshare_popup', $links, $html);
+    print theme('simpleshare_popup', $links, $title);
   }
   exit;
 }


### PR DESCRIPTION
This fixes the h2 title in the javascript popup. The changes that made the tinyurl code Twitter-only broke this.
